### PR TITLE
Update azure-webapp-maven-plugin to current version to prevent errors in newer versions of Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,16 +195,33 @@ Tomcat in App Service Linux:
 <plugin>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-webapp-maven-plugin</artifactId>
-    <version>1.5.3</version>
+    <version>2.5.0</version>
     <configuration>
 
         <!-- Web App information -->
-        <resourceGroup>${RESOURCEGROUP_NAME}</resourceGroup>
-        <appServicePlanName>${WEBAPP_PLAN_NAME}-${REGION}</appServicePlanName>
-        <appName>${WEBAPP_NAME}-${REGION}</appName>
-        <region>${REGION}</region>
-        <linuxRuntime>tomcat 9.0-jre8</linuxRuntime>
-
+    <schemaVersion>v2</schemaVersion>
+    <subscriptionId>${SUBSCRIPTION_ID}</subscriptionId>
+    <resourceGroup>${RESOURCEGROUP_NAME}</resourceGroup>
+    <appName>${WEBAPP_NAME}-${REGION}</appName>
+    <pricingTier>P1v2</pricingTier>
+    <region>${REGION}</region>
+    <appServicePlanName>${WEBAPP_PLAN_NAME}-${REGION}</appServicePlanName>
+    <appServicePlanResourceGroup>${RESOURCEGROUP_NAME}</appServicePlanResourceGroup>
+    <runtime>
+        <os>Linux</os>
+        <javaVersion>Java 8</javaVersion>
+        <webContainer>Tomcat 9.0</webContainer>
+    </runtime>
+    <deployment>
+        <resources>
+        <resource>
+            <directory>${project.basedir}/target</directory>
+            <includes>
+            <include>*.war</include>
+            </includes>
+        </resource>
+        </resources>
+    </deployment>
         <appSettings>
             <property>
                 <name>JAVA_OPTS</name>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Running these instructions in newer versions of Java fails because the `azure-webapp-maven-plugin` expects the JAXB library to be available in the JDK, but it's removed in Java 11 and later

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Test with Java 11 or later
* Before this PR, the step `mvn azure-webapp:deploy -DREGION=${REGION_1}` from the README will fail with an error like:
```
[ERROR] Failed to execute goal com.microsoft.azure:azure-webapp-maven-plugin:1.5.3:deploy (default-cli) on project Stateful-Tracker: Execution default-cli of goal com.microsoft.azure:azure-webapp-maven-plugin:1.5.3:deploy failed: A required class was missing while executing com.microsoft.azure:azure-webapp-maven-plugin:1.5.3:deploy: javax/xml/bind/JAXBException
```
With the change from this PR, the command should succeed, because it uses a newer version of the plugin and updated configuration.

## Other Information
<!-- Add any other helpful information that may be needed here. -->